### PR TITLE
CBMC uses --graphml-witness instead of --graphml-cex

### DIFF
--- a/benchmark-defs/cbmc.xml
+++ b/benchmark-defs/cbmc.xml
@@ -8,7 +8,7 @@
   
   <rundefinition name="sv-comp17"></rundefinition>
 
-  <option name="--graphml-cex">error-witness.graphml</option>
+  <option name="--graphml-witness">error-witness.graphml</option>
 
   <tasks name="ArraysReach">
     <includesfile>../sv-benchmarks/c/ArraysReach.set</includesfile>


### PR DESCRIPTION
As CBMC is, for the competition, encapsulated in a wrapper script this
change is not essential. For consistency, however, it will be a cleaner
set up for future competitons.