### PR TITLE
updating the option CIVL uses for svcomp 2017

### DIFF
--- a/benchmark-defs/civl.xml
+++ b/benchmark-defs/civl.xml
@@ -9,7 +9,7 @@
   <rundefinition name="sv-comp17"></rundefinition>
 
   <option name="verify"/>
-  <option name="-svcomp16"/>
+  <option name="-svcomp17"/>
 
   <tasks name="ConcurrencySafety-Main">
     <includesfile>../sv-benchmarks/c/ConcurrencySafety-Main.set</includesfile>


### PR DESCRIPTION
uses the option "-svcomp17" for SVCOMP 2017.