### PR TITLE
Added benchmark definition for VIAP

### DIFF
--- a/benchmark-defs/viap.xml
+++ b/benchmark-defs/viap.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<!DOCTYPE benchmark PUBLIC "+//IDN sosy-lab.org//DTD BenchExec benchmark 1.4//EN" "http://www.sosy-lab.org/benchexec/benchmark-1.4.dtd">
+<benchmark tool="map2check" timelimit="900 s" memlimit="15 GB" cpuCores="8">
+
+<require cpuModel="Intel Xeon E3-1230 v5 @ 3.40 GHz" cpuCores="8"/>
+
+  <resultfiles>**.graphml</resultfiles>
+  
+  <rundefinition name="sv-comp18"></rundefinition>
+
+  <tasks name="ReachSafety-Arrays">
+    <includesfile>../sv-benchmarks/c/ReachSafety-Arrays.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/ReachSafety.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-Loops">
+    <includesfile>../sv-benchmarks/c/ReachSafety-Loops.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/ReachSafety.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-Recursive">
+    <includesfile>../sv-benchmarks/c/ReachSafety-Recursive.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/ReachSafety.prp</propertyfile>
+  </tasks>
+</benchmark>


### PR DESCRIPTION
<?xml version="1.0"?>
<!DOCTYPE benchmark PUBLIC "+//IDN sosy-lab.org//DTD BenchExec benchmark 1.4//EN" "http://www.sosy-lab.org/benchexec/benchmark-1.4.dtd">
<benchmark tool="map2check" timelimit="900 s" memlimit="15 GB" cpuCores="8">

<require cpuModel="Intel Xeon E3-1230 v5 @ 3.40 GHz" cpuCores="8"/>

  <resultfiles>**.graphml</resultfiles>
  
  <rundefinition name="sv-comp18"></rundefinition>

  <tasks name="ReachSafety-Arrays">
    <includesfile>../sv-benchmarks/c/ReachSafety-Arrays.set</includesfile>
    <propertyfile>../sv-benchmarks/c/ReachSafety.prp</propertyfile>
  </tasks>
  <tasks name="ReachSafety-Loops">
    <includesfile>../sv-benchmarks/c/ReachSafety-Loops.set</includesfile>
    <propertyfile>../sv-benchmarks/c/ReachSafety.prp</propertyfile>
  </tasks>
  <tasks name="ReachSafety-Recursive">
    <includesfile>../sv-benchmarks/c/ReachSafety-Recursive.set</includesfile>
    <propertyfile>../sv-benchmarks/c/ReachSafety.prp</propertyfile>
  </tasks>
</benchmark>