### PR TITLE
Changed tool in CPA-BAM-Slicing benchmark definition to "cpachecker".

### DIFF
--- a/benchmark-defs/cpa-bam-slicing.xml
+++ b/benchmark-defs/cpa-bam-slicing.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE benchmark PUBLIC "+//IDN sosy-lab.org//DTD BenchExec benchmark 1.4//EN" "http://www.sosy-lab.org/benchexec/benchmark-1.4.dtd">
-<benchmark tool="cpa-bam-slicing" timelimit="900 s" memlimit="15 GB" cpuCores="8">
+<benchmark tool="cpachecker" timelimit="900 s" memlimit="15 GB" cpuCores="8">
 
 <require cpuModel="Intel Xeon E3-1230 v5 @ 3.40 GHz" cpuCores="8"/>
 


### PR DESCRIPTION
"cpa-bam-slicing" tool description is not needed anymore, the slicer is now executed from cpa.sh (also closes [this](https://github.com/sosy-lab/benchexec/pull/266) PR)