### PR TITLE
update interpchecker.xml

### DIFF
--- a/benchmark-defs/interpchecker.xml
+++ b/benchmark-defs/interpchecker.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE benchmark PUBLIC "+//IDN sosy-lab.org//DTD BenchExec benchmark 1.4//EN" "http://www.sosy-lab.org/benchexec/benchmark-1.4.dtd">
-<benchmark tool="interpchecker" timelimit="900 s" hardtimelimit="960 s" memlimit="15 GB" cpuCores="8">
+<benchmark tool="cpachecker" timelimit="900 s" hardtimelimit="960 s" memlimit="15 GB" cpuCores="8">
 
 <require cpuModel="Intel Xeon E3-1230 v5 @ 3.40 GHz" cpuCores="8"/>
 
@@ -42,10 +42,6 @@
   </tasks>
   <tasks name="ReachSafety-ProductLines">
     <includesfile>../sv-benchmarks/c/ReachSafety-ProductLines.set</includesfile>
-    <propertyfile>../sv-benchmarks/c/ReachSafety.prp</propertyfile>
-  </tasks>
-  <tasks name="ReachSafety-Recursive">
-    <includesfile>../sv-benchmarks/c/ReachSafety-Recursive.set</includesfile>
     <propertyfile>../sv-benchmarks/c/ReachSafety.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-Sequentialized">


### PR DESCRIPTION
I use cpachecker instead of interpchecker  in the benchmark tool option.  Meanwhile,  I remove the category  ReachSafety-Recursive