### PR TITLE
updating for the 2018 competition

### DIFF
--- a/benchmark-defs/skink.xml
+++ b/benchmark-defs/skink.xml
@@ -8,20 +8,41 @@
   
   <rundefinition name="sv-comp18"></rundefinition>
 
-  <tasks name="ReachSafety-BitVectors">
+  <tasks name="ReachSafety-Arrays">
+    <includesfile>../sv-benchmarks/c/ReachSafety-Arrays.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/ReachSafety.prp</propertyfile>
+    <option name="cmp"></option>
+ </tasks>
+ <tasks name="ReachSafety-BitVectors">
     <includesfile>../sv-benchmarks/c/ReachSafety-BitVectors.set</includesfile>
     <propertyfile>../sv-benchmarks/c/ReachSafety.prp</propertyfile>
     <option name="cmp"></option>
     <option name="-i">bit</option>
   </tasks>
+  <tasks name="ReachSafety-ControlFlow">
+    <includesfile>../sv-benchmarks/c/ReachSafety-ControlFlow.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/ReachSafety.prp</propertyfile>
+    <option name="cmp"></option>
+  </tasks>
+  <tasks name="ReachSafety-Floats">
+    <includesfile>../sv-benchmarks/c/ReachSafety-Floats.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/ReachSafety.prp</propertyfile>
+    <option name="cmp"></option>
+    <option name="-e">Yices-nonIncr</option>
+  </tasks>
+  <tasks name="ReachSafety-Heap">
+    <includesfile>../sv-benchmarks/c/ReachSafety-Heap.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/ReachSafety.prp</propertyfile>
+    <option name="cmp"></option>
+  </tasks>
+  <tasks name="ReachSafety-Recursive">
+    <includesfile>../sv-benchmarks/c/ReachSafety-Recursive.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/ReachSafety.prp</propertyfile>
+    <option name="cmp"></option>
+  </tasks>
   <tasks name="ReachSafety-Loops">
     <includesfile>../sv-benchmarks/c/ReachSafety-Loops.set</includesfile>
     <propertyfile>../sv-benchmarks/c/ReachSafety.prp</propertyfile>
     <option name="cmp"></option>
-  </tasks>
-  <tasks name="ConcurrencySafety-Main">
-    <includesfile>../sv-benchmarks/c/ConcurrencySafety-Main.set</includesfile>
-    <propertyfile>../sv-benchmarks/c/ConcurrencySafety.prp</propertyfile>
-    <option name="exp"></option>
   </tasks>
 </benchmark>


### PR DESCRIPTION
skink won't compete in concurrency in 2018 but will add arrays, floats, recursive and heaps (all reach-safety).