### PR TITLE
Set an option for CPAchecker to assume that memory allocations always…

### DIFF
--- a/benchmark-defs/cpa-seq-validate-correctness-witnesses.xml
+++ b/benchmark-defs/cpa-seq-validate-correctness-witnesses.xml
@@ -15,6 +15,7 @@
   <option name="-disable-java-assertions"/>
   <option name="-heap">5000m</option>
   <option name="-witness">../../results-verified/LOGDIR/sv-comp18.${inputfile_name}.files/witness.graphml</option>
+  <option name="-setprop">cpa.predicate.memoryAllocationsAlwaysSucceed=true</option>
 
   <tasks name="ReachSafety-Arrays">
     <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>

--- a/benchmark-defs/cpa-seq-validate-violation-witnesses.xml
+++ b/benchmark-defs/cpa-seq-validate-violation-witnesses.xml
@@ -15,6 +15,7 @@
   <option name="-disable-java-assertions"/>
   <option name="-heap">5000m</option>
   <option name="-witness">../../results-verified/LOGDIR/sv-comp18.${inputfile_name}.files/witness.graphml</option>
+  <option name="-setprop">cpa.predicate.memoryAllocationsAlwaysSucceed=true</option>
 
   <tasks name="ReachSafety-Arrays">
     <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>


### PR DESCRIPTION
… succeed; this SV-COMP-specific assumption is no longer part of the default configuration for witness validation, so it must be set explicitly.