### PR TITLE
Remove unsupported categories from benchmark definition of CPAchecker correctness-witness validator

### DIFF
--- a/benchmark-defs/cpa-seq-validate-correctness-witnesses.xml
+++ b/benchmark-defs/cpa-seq-validate-correctness-witnesses.xml
@@ -68,61 +68,6 @@
     <propertyfile>../sv-benchmarks/c/ReachSafety.prp</propertyfile>
   </tasks>
 
-  <tasks name="MemSafety-Arrays">
-    <exclude>../sv-benchmarks/c/*/*_false-valid-deref*</exclude>
-    <exclude>../sv-benchmarks/c/*/*_false-valid-free*</exclude>
-    <exclude>../sv-benchmarks/c/*/*_false-valid-memtrack*</exclude>
-    <includesfile>../sv-benchmarks/c/MemSafety-Arrays.set</includesfile>
-    <propertyfile>../sv-benchmarks/c/MemSafety.prp</propertyfile>
-  </tasks>
-  <tasks name="MemSafety-Heap">
-    <exclude>../sv-benchmarks/c/*/*_false-valid-deref*</exclude>
-    <exclude>../sv-benchmarks/c/*/*_false-valid-free*</exclude>
-    <exclude>../sv-benchmarks/c/*/*_false-valid-memtrack*</exclude>
-    <includesfile>../sv-benchmarks/c/MemSafety-Heap.set</includesfile>
-    <propertyfile>../sv-benchmarks/c/MemSafety.prp</propertyfile>
-  </tasks>
-  <tasks name="MemSafety-LinkedLists">
-    <exclude>../sv-benchmarks/c/*/*_false-valid-deref*</exclude>
-    <exclude>../sv-benchmarks/c/*/*_false-valid-free*</exclude>
-    <exclude>../sv-benchmarks/c/*/*_false-valid-memtrack*</exclude>
-    <includesfile>../sv-benchmarks/c/MemSafety-LinkedLists.set</includesfile>
-    <propertyfile>../sv-benchmarks/c/MemSafety.prp</propertyfile>
-  </tasks>
-  <tasks name="MemSafety-Other">
-    <exclude>../sv-benchmarks/c/*/*_false-valid-deref*</exclude>
-    <exclude>../sv-benchmarks/c/*/*_false-valid-free*</exclude>
-    <exclude>../sv-benchmarks/c/*/*_false-valid-memtrack*</exclude>
-    <includesfile>../sv-benchmarks/c/MemSafety-Other.set</includesfile>
-    <propertyfile>../sv-benchmarks/c/MemSafety.prp</propertyfile>
-  </tasks>
-
-  <tasks name="NoOverflows-BitVectors">
-    <exclude>../sv-benchmarks/c/*/*_false-no-overflow*</exclude>
-    <includesfile>../sv-benchmarks/c/NoOverflows-BitVectors.set</includesfile>
-    <propertyfile>../sv-benchmarks/c/NoOverflows.prp</propertyfile>
-    <option name="-64"/>
-  </tasks>
-  <tasks name="NoOverflows-Other">
-    <exclude>../sv-benchmarks/c/*/*_false-no-overflow*</exclude>
-    <includesfile>../sv-benchmarks/c/NoOverflows-Other.set</includesfile>
-    <propertyfile>../sv-benchmarks/c/NoOverflows.prp</propertyfile>
-  </tasks>
-
-  <tasks name="Systems_BusyBox_MemSafety">
-    <exclude>../sv-benchmarks/c/*/*_false-valid-deref*</exclude>
-    <exclude>../sv-benchmarks/c/*/*_false-valid-free*</exclude>
-    <exclude>../sv-benchmarks/c/*/*_false-valid-memtrack*</exclude>
-    <includesfile>../sv-benchmarks/c/Systems_BusyBox_MemSafety.set</includesfile>
-    <propertyfile>../sv-benchmarks/c/Systems_BusyBox_MemSafety.prp</propertyfile>
-    <option name="-64"/>
-  </tasks>
-  <tasks name="Systems_BusyBox_NoOverflows">
-    <exclude>../sv-benchmarks/c/*/*_false-no-overflow*</exclude>
-    <includesfile>../sv-benchmarks/c/Systems_BusyBox_NoOverflows.set</includesfile>
-    <propertyfile>../sv-benchmarks/c/Systems_BusyBox_NoOverflows.prp</propertyfile>
-    <option name="-64"/>
-  </tasks>
   <tasks name="Systems_DeviceDriversLinux64_ReachSafety">
     <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/Systems_DeviceDriversLinux64_ReachSafety.set</includesfile>


### PR DESCRIPTION
Remove unsupported categories from benchmark definition of CPAchecker correctness-witness validator