### PR TITLE
symbiotic.xml: fix architecture with bitvectors

### DIFF
--- a/benchmark-defs/symbiotic.xml
+++ b/benchmark-defs/symbiotic.xml
@@ -91,7 +91,6 @@
   <tasks name="NoOverflows-BitVectors">
     <includesfile>../sv-benchmarks/c/NoOverflows-BitVectors.set</includesfile>
     <propertyfile>../sv-benchmarks/c/NoOverflows.prp</propertyfile>
-    <option name="--32"/>
   </tasks>
   <tasks name="NoOverflows-Other">
     <includesfile>../sv-benchmarks/c/NoOverflows-Other.set</includesfile>


### PR DESCRIPTION
NoOverflows-Bitvectors is 64-bit