### PR TITLE
Rename jpf to spf

### DIFF
--- a/benchmark-defs/spf.xml
+++ b/benchmark-defs/spf.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE benchmark PUBLIC "+//IDN sosy-lab.org//DTD BenchExec benchmark 1.4//EN" "http://www.sosy-lab.org/benchexec/benchmark-1.4.dtd">
-<benchmark tool="jpf" timelimit="900 s" memlimit="15 GB" cpuCores="8">
+<benchmark tool="spf" timelimit="900 s" memlimit="15 GB" cpuCores="8">
 
 <require cpuModel="Intel Xeon E3-1230 v5 @ 3.40 GHz" cpuCores="8"/>
 


### PR DESCRIPTION
JPF is now JPF-core. Therefore it makes more sense to call the symbolic version SPF.