### PR TITLE
Update CPA-Seq-related benchmark definitions

### DIFF
--- a/benchmark-defs/cpa-seq-validate-correctness-witnesses.xml
+++ b/benchmark-defs/cpa-seq-validate-correctness-witnesses.xml
@@ -12,7 +12,7 @@
   <option name="-benchmark"/>
   <option name="-setprop">cpa.predicate.memoryAllocationsAlwaysSucceed=true</option>
 
-<rundefinition name="sv-comp19_prop-reachsafety">
+<rundefinition name="sv-comp20_prop-reachsafety">
   <requiredfiles>../results-verified/LOGDIR/${rundefinition_name}.${inputfile_name}.files/witness.graphml</requiredfiles>
   <option name="-witness">../../results-verified/LOGDIR/${rundefinition_name}.${inputfile_name}.files/witness.graphml</option>
 

--- a/benchmark-defs/cpa-seq-validate-violation-witnesses.xml
+++ b/benchmark-defs/cpa-seq-validate-violation-witnesses.xml
@@ -17,7 +17,7 @@
   <option name="-setprop">cpa.smg.zeroingMemoryAllocation=calloc,kzalloc,kcalloc,kzalloc_node,ldv_zalloc</option>
   <option name="-setprop">cpa.smg.deallocationFunctions=free,kfree,kfree_const</option>
 
-<rundefinition name="sv-comp19_prop-reachsafety">
+<rundefinition name="sv-comp20_prop-reachsafety">
   <requiredfiles>../results-verified/LOGDIR/${rundefinition_name}.${inputfile_name}.files/witness.graphml</requiredfiles>
   <option name="-witness">../../results-verified/LOGDIR/${rundefinition_name}.${inputfile_name}.files/witness.graphml</option>
 
@@ -86,7 +86,7 @@
   </tasks>
 </rundefinition>
 
-<rundefinition name="sv-comp19_prop-memsafety">
+<rundefinition name="sv-comp20_prop-memsafety">
   <requiredfiles>../results-verified/LOGDIR/${rundefinition_name}.${inputfile_name}.files/witness.graphml</requiredfiles>
   <option name="-witness">../../results-verified/LOGDIR/${rundefinition_name}.${inputfile_name}.files/witness.graphml</option>
 
@@ -124,7 +124,7 @@
   </tasks>
 </rundefinition>
 
-<rundefinition name="sv-comp19_prop-nooverflow">
+<rundefinition name="sv-comp20_prop-nooverflow">
   <requiredfiles>../results-verified/LOGDIR/${rundefinition_name}.${inputfile_name}.files/witness.graphml</requiredfiles>
   <option name="-witness">../../results-verified/LOGDIR/${rundefinition_name}.${inputfile_name}.files/witness.graphml</option>
 
@@ -148,7 +148,7 @@
   </tasks>
 </rundefinition>
 
-<rundefinition name="sv-comp19_prop-termination">
+<rundefinition name="sv-comp20_prop-termination">
   <requiredfiles>../results-verified/LOGDIR/${rundefinition_name}.${inputfile_name}.files/witness.graphml</requiredfiles>
   <option name="-witness">../../results-verified/LOGDIR/${rundefinition_name}.${inputfile_name}.files/witness.graphml</option>
 

--- a/benchmark-defs/cpa-seq.xml
+++ b/benchmark-defs/cpa-seq.xml
@@ -6,12 +6,12 @@
 
   <resultfiles>**.graphml</resultfiles>
 
-  <option name="-svcomp19"/>
+  <option name="-svcomp20"/>
   <option name="-heap">10000M</option>
   <option name="-benchmark"/>
   <option name="-timelimit">900 s</option>
 
-<rundefinition name="sv-comp19_prop-reachsafety">
+<rundefinition name="sv-comp20_prop-reachsafety">
   <tasks name="ReachSafety-Arrays">
     <includesfile>../sv-benchmarks/c/ReachSafety-Arrays.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
@@ -65,7 +65,7 @@
   </tasks>
 </rundefinition>
 
-<rundefinition name="sv-comp19_prop-memsafety">
+<rundefinition name="sv-comp20_prop-memsafety">
   <tasks name="MemSafety-Arrays">
     <includesfile>../sv-benchmarks/c/MemSafety-Arrays.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
@@ -94,7 +94,7 @@
   </tasks>
 </rundefinition>
 
-<rundefinition name="sv-comp19_prop-nooverflow">
+<rundefinition name="sv-comp20_prop-nooverflow">
   <tasks name="NoOverflows-BitVectors">
     <includesfile>../sv-benchmarks/c/NoOverflows-BitVectors.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
@@ -112,7 +112,7 @@
   </tasks>
 </rundefinition>
 
-<rundefinition name="sv-comp19_prop-termination">
+<rundefinition name="sv-comp20_prop-termination">
   <tasks name="Termination-MainControlFlow">
     <includesfile>../sv-benchmarks/c/Termination-MainControlFlow.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/termination.prp</propertyfile>

--- a/benchmark-defs/cpa-undef-func.xml
+++ b/benchmark-defs/cpa-undef-func.xml
@@ -11,7 +11,7 @@
   <option name="-benchmark"/>
   <option name="-timelimit">900 s</option>
 
-<rundefinition name="sv-comp19_prop-reachsafety_undef-func">
+<rundefinition name="sv-comp20_prop-reachsafety_undef-func">
   <tasks name="ReachSafety-Arrays">
     <includesfile>../sv-benchmarks/c/ReachSafety-Arrays.set</includesfile>
   </tasks>
@@ -53,7 +53,7 @@
   </tasks>
 </rundefinition>
 
-<rundefinition name="sv-comp19_prop-memsafety_undef-func">
+<rundefinition name="sv-comp20_prop-memsafety_undef-func">
   <tasks name="MemSafety-Arrays">
     <includesfile>../sv-benchmarks/c/MemSafety-Arrays.set</includesfile>
   </tasks>
@@ -76,7 +76,7 @@
   </tasks>
 </rundefinition>
 
-<rundefinition name="sv-comp19_prop-nooverflow_undef-func">
+<rundefinition name="sv-comp20_prop-nooverflow_undef-func">
   <tasks name="NoOverflows-BitVectors">
     <includesfile>../sv-benchmarks/c/NoOverflows-BitVectors.set</includesfile>
     <option name="-64"/>
@@ -91,7 +91,7 @@
   </tasks>
 </rundefinition>
 
-<rundefinition name="sv-comp19_prop-termination_undef-func">
+<rundefinition name="sv-comp20_prop-termination_undef-func">
   <tasks name="Termination-MainControlFlow">
     <includesfile>../sv-benchmarks/c/Termination-MainControlFlow.set</includesfile>
     <option name="-64"/>

--- a/benchmark-defs/cpa-witness2test-validate-violation-witnesses.xml
+++ b/benchmark-defs/cpa-witness2test-validate-violation-witnesses.xml
@@ -14,7 +14,7 @@
   <option name="-setprop">cpa.callstack.skipVoidRecursion=true</option>
   <option name="-setprop">cpa.callstack.skipFunctionPointerRecursion=true</option>
 
-<rundefinition name="sv-comp19_prop-reachsafety">
+<rundefinition name="sv-comp20_prop-reachsafety">
   <requiredfiles>../results-verified/LOGDIR/${rundefinition_name}.${inputfile_name}.files/witness.graphml</requiredfiles>
   <option name="-witness">../../results-verified/LOGDIR/${rundefinition_name}.${inputfile_name}.files/witness.graphml</option>
 
@@ -77,7 +77,7 @@
   </tasks>
 </rundefinition>
 
-<rundefinition name="sv-comp19_prop-memsafety">
+<rundefinition name="sv-comp20_prop-memsafety">
   <requiredfiles>../results-verified/LOGDIR/${rundefinition_name}.${inputfile_name}.files/witness.graphml</requiredfiles>
   <option name="-witness">../../results-verified/LOGDIR/${rundefinition_name}.${inputfile_name}.files/witness.graphml</option>
 
@@ -110,7 +110,7 @@
   </tasks>
 </rundefinition>
 
-<rundefinition name="sv-comp19_prop-nooverflow">
+<rundefinition name="sv-comp20_prop-nooverflow">
   <requiredfiles>../results-verified/LOGDIR/${rundefinition_name}.${inputfile_name}.files/witness.graphml</requiredfiles>
   <option name="-witness">../../results-verified/LOGDIR/${rundefinition_name}.${inputfile_name}.files/witness.graphml</option>
 


### PR DESCRIPTION
I changed the configuration name to `svcomp20` and also took the freedom of updating the rundefinition names in CPA-Seq related benchmark definitions to `*sv-comp20*`.