### PR TITLE
Add definition for Nitwit Validator

### DIFF
--- a/benchmark-defs/val_nitwit.xml
+++ b/benchmark-defs/val_nitwit.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0"?>
+<!DOCTYPE benchmark PUBLIC "+//IDN sosy-lab.org//DTD BenchExec benchmark 1.4//EN"
+        "http://www.sosy-lab.org/benchexec/benchmark-1.4.dtd">
+<benchmark tool="val_nitwit" timelimit="90 s" hardtimelimit="96 s" memlimit="7 GB" cpuCores="1">
+
+    <require cpuModel="Intel Xeon E3-1230 v5 @ 3.40 GHz" cpuCores="1"/>
+
+    <resultfiles>**.graphml</resultfiles>
+
+    <rundefinition name="sv-comp19_prop-reachsafety">
+        <requiredfiles>../results-verified/LOGDIR/${rundefinition_name}.${inputfile_name}.files/witness.graphml</requiredfiles>
+        <option name="">../../results-verified/LOGDIR/${rundefinition_name}.${inputfile_name}.files/witness.graphml</option>
+
+        <tasks name="ReachSafety-Arrays">
+            <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
+            <includesfile>../sv-benchmarks/c/ReachSafety-Arrays.set</includesfile>
+            <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+        </tasks>
+        <tasks name="ReachSafety-BitVectors">
+            <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
+            <includesfile>../sv-benchmarks/c/ReachSafety-BitVectors.set</includesfile>
+            <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+        </tasks>
+        <tasks name="ReachSafety-ControlFlow">
+            <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
+            <includesfile>../sv-benchmarks/c/ReachSafety-ControlFlow.set</includesfile>
+            <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+        </tasks>
+        <tasks name="ReachSafety-ECA">
+            <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
+            <includesfile>../sv-benchmarks/c/ReachSafety-ECA.set</includesfile>
+            <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+        </tasks>
+        <tasks name="ReachSafety-Floats">
+            <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
+            <includesfile>../sv-benchmarks/c/ReachSafety-Floats.set</includesfile>
+            <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+        </tasks>
+        <tasks name="ReachSafety-Heap">
+            <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
+            <includesfile>../sv-benchmarks/c/ReachSafety-Heap.set</includesfile>
+            <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+        </tasks>
+        <tasks name="ReachSafety-Loops">
+            <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
+            <includesfile>../sv-benchmarks/c/ReachSafety-Loops.set</includesfile>
+            <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+        </tasks>
+        <tasks name="ReachSafety-ProductLines">
+            <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
+            <includesfile>../sv-benchmarks/c/ReachSafety-ProductLines.set</includesfile>
+            <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+        </tasks>
+        <tasks name="ReachSafety-Recursive">
+            <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
+            <includesfile>../sv-benchmarks/c/ReachSafety-Recursive.set</includesfile>
+            <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+        </tasks>
+        <tasks name="ReachSafety-Sequentialized">
+            <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
+            <includesfile>../sv-benchmarks/c/ReachSafety-Sequentialized.set</includesfile>
+            <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+        </tasks>
+    </rundefinition>
+
+</benchmark>

--- a/benchmark-defs/val_nitwit.xml
+++ b/benchmark-defs/val_nitwit.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <!DOCTYPE benchmark PUBLIC "+//IDN sosy-lab.org//DTD BenchExec benchmark 1.4//EN"
         "http://www.sosy-lab.org/benchexec/benchmark-1.4.dtd">
-<benchmark tool="val_nitwit" timelimit="90 s" hardtimelimit="96 s" memlimit="7 GB" cpuCores="1">
+<benchmark tool="val_nitwit" timelimit="90 s" hardtimelimit="96 s" memlimit="7 GB" cpuCores="2">
 
-    <require cpuModel="Intel Xeon E3-1230 v5 @ 3.40 GHz" cpuCores="1"/>
+    <require cpuModel="Intel Xeon E3-1230 v5 @ 3.40 GHz" cpuCores="2"/>
 
     <resultfiles>**.graphml</resultfiles>
 


### PR DESCRIPTION
A BenchExec benchmark definition for the Nitwit Validator. We restrict ourselves only to the ReachSafety category (without Software Systems). The validator is sequential and only ever uses 1 core so we changed the argument "cpuCores" to 1. Or should that be left to "2" even if we can't use the second core?

Note:
Pull request for the tool-info here:
https://github.com/sosy-lab/benchexec/pull/451
