### PR TITLE
Adding the Java Ranger benchmark-defs file

### DIFF
--- a/benchmark-defs/java-ranger.xml
+++ b/benchmark-defs/java-ranger.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!DOCTYPE benchmark PUBLIC "+//IDN sosy-lab.org//DTD BenchExec benchmark 1.9//EN" "http://www.sosy-lab.org/benchexec/benchmark-1.9.dtd">
+<benchmark tool="java-ranger" timelimit="15 min" memlimit="15 GB" cpuCores="8">
+
+<require cpuModel="Intel Xeon E3-1230 v5 @ 3.40 GHz" cpuCores="8"/>
+
+  <resultfiles>**.graphml</resultfiles>
+
+<rundefinition name="sv-comp19_prop-reachsafety_java">
+  <tasks name="ReachSafety-Java">
+    <includesfile>../sv-benchmarks/java/ReachSafety.set</includesfile>
+    <propertyfile>../sv-benchmarks/java/properties/assert.prp</propertyfile>
+  </tasks>
+</rundefinition>
+
+</benchmark>


### PR DESCRIPTION
This pull request adds the benchmark definition of Java Ranger so that it can participate in the JavaOverAll category of SV-COMP 2020. 