### PR TITLE
Add benchmark definition for JDart

### DIFF
--- a/benchmark-defs/jdart.xml
+++ b/benchmark-defs/jdart.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!DOCTYPE benchmark PUBLIC "+//IDN sosy-lab.org//DTD BenchExec benchmark 1.9//EN" "http://www.sosy-lab.org/benchexec/benchmark-1.9.dtd">
+<benchmark tool="jdart" timelimit="15 min" memlimit="15 GB" cpuCores="8">
+
+<require cpuModel="Intel Xeon E3-1230 v5 @ 3.40 GHz" cpuCores="8"/>
+
+  <resultfiles>**.graphml</resultfiles>
+
+<rundefinition name="sv-comp20_prop-reachsafety_java">
+  <tasks name="ReachSafety-Java">
+    <includesfile>../sv-benchmarks/java/ReachSafety.set</includesfile>
+    <propertyfile>../sv-benchmarks/java/properties/assert.prp</propertyfile>
+  </tasks>
+</rundefinition>
+
+</benchmark>


### PR DESCRIPTION
In alignment with the [tool info](https://github.com/sosy-lab/benchexec/pull/456) for JDart, we want to add a benchmark_def for JDart.