### PR TITLE
Remove ineffective exclude directives

### DIFF
--- a/benchmark-defs/cpa-seq-validate-correctness-witnesses.xml
+++ b/benchmark-defs/cpa-seq-validate-correctness-witnesses.xml
@@ -17,58 +17,47 @@
   <option name="-witness">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
 
   <tasks name="ReachSafety-Arrays">
-    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Arrays.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-BitVectors">
-    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-BitVectors.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-ControlFlow">
-    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-ControlFlow.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-ECA">
-    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-ECA.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-Floats">
-    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Floats.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-Heap">
-    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Heap.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-Loops">
-    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Loops.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-ProductLines">
-    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-ProductLines.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-Recursive">
-    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Recursive.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-Sequentialized">
-    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Sequentialized.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
 
   <tasks name="SoftwareSystems-DeviceDriversLinux64-ReachSafety">
-    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/SoftwareSystems-DeviceDriversLinux64-ReachSafety.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="-64"/>

--- a/benchmark-defs/cpa-seq-validate-violation-witnesses.xml
+++ b/benchmark-defs/cpa-seq-validate-violation-witnesses.xml
@@ -22,64 +22,52 @@
   <option name="-witness">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
 
   <tasks name="ReachSafety-Arrays">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Arrays.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-BitVectors">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-BitVectors.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-ControlFlow">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-ControlFlow.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-ECA">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-ECA.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-Floats">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Floats.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-Heap">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Heap.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-Loops">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Loops.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-ProductLines">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-ProductLines.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-Recursive">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Recursive.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-Sequentialized">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Sequentialized.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
 
   <tasks name="ConcurrencySafety-Main">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ConcurrencySafety-Main.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
 
   <tasks name="SoftwareSystems-DeviceDriversLinux64-ReachSafety">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/SoftwareSystems-DeviceDriversLinux64-ReachSafety.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="-64"/>
@@ -91,22 +79,18 @@
   <option name="-witness">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
 
   <tasks name="MemSafety-Arrays">
-    <exclude>../sv-benchmarks/c/*/*_true-valid-memsafety*</exclude>
     <includesfile>../sv-benchmarks/c/MemSafety-Arrays.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
   </tasks>
   <tasks name="MemSafety-Heap">
-    <exclude>../sv-benchmarks/c/*/*_true-valid-memsafety*</exclude>
     <includesfile>../sv-benchmarks/c/MemSafety-Heap.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
   </tasks>
   <tasks name="MemSafety-LinkedLists">
-    <exclude>../sv-benchmarks/c/*/*_true-valid-memsafety*</exclude>
     <includesfile>../sv-benchmarks/c/MemSafety-LinkedLists.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
   </tasks>
   <tasks name="MemSafety-Other">
-    <exclude>../sv-benchmarks/c/*/*_true-valid-memsafety*</exclude>
     <includesfile>../sv-benchmarks/c/MemSafety-Other.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
   </tasks>
@@ -116,13 +100,11 @@
     <option name="-64"/>
   </tasks>
   <tasks name="MemSafety-MemCleanup">
-    <exclude>../sv-benchmarks/c/*/*_true-valid-memcleanup*</exclude>
     <includesfile>../sv-benchmarks/c/MemSafety-MemCleanup.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memcleanup.prp</propertyfile>
   </tasks>
 
   <tasks name="SoftwareSystems-BusyBox-MemSafety">
-    <exclude>../sv-benchmarks/c/*/*_true-valid-memsafety*</exclude>
     <includesfile>../sv-benchmarks/c/SoftwareSystems-BusyBox-MemSafety.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
     <option name="-64"/>
@@ -134,19 +116,16 @@
   <option name="-witness">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
 
   <tasks name="NoOverflows-BitVectors">
-    <exclude>../sv-benchmarks/c/*/*_true-no-overflow*</exclude>
     <includesfile>../sv-benchmarks/c/NoOverflows-BitVectors.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
     <option name="-64"/>
   </tasks>
   <tasks name="NoOverflows-Other">
-    <exclude>../sv-benchmarks/c/*/*_true-no-overflow*</exclude>
     <includesfile>../sv-benchmarks/c/NoOverflows-Other.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
   </tasks>
 
   <tasks name="SoftwareSystems-BusyBox-NoOverflows">
-    <exclude>../sv-benchmarks/c/*/*_true-no-overflow*</exclude>
     <includesfile>../sv-benchmarks/c/SoftwareSystems-BusyBox-NoOverflows.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
     <option name="-64"/>
@@ -158,19 +137,16 @@
   <option name="-witness">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
 
   <tasks name="Termination-MainControlFlow">
-    <exclude>../sv-benchmarks/c/*/*_true-termination*</exclude>
     <includesfile>../sv-benchmarks/c/Termination-MainControlFlow.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/termination.prp</propertyfile>
     <option name="-64"/>
   </tasks>
   <tasks name="Termination-MainHeap">
-    <exclude>../sv-benchmarks/c/*/*_true-termination*</exclude>
     <includesfile>../sv-benchmarks/c/Termination-MainHeap.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/termination.prp</propertyfile>
     <option name="-64"/>
   </tasks>
   <tasks name="Termination-Other">
-    <exclude>../sv-benchmarks/c/*/*_true-termination*</exclude>
     <includesfile>../sv-benchmarks/c/Termination-Other.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/termination.prp</propertyfile>
   </tasks>

--- a/benchmark-defs/cpa-witness2test-validate-violation-witnesses.xml
+++ b/benchmark-defs/cpa-witness2test-validate-violation-witnesses.xml
@@ -19,58 +19,47 @@
   <option name="-witness">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
 
   <tasks name="ReachSafety-Arrays">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Arrays.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-BitVectors">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-BitVectors.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-ControlFlow">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-ControlFlow.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-ECA">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-ECA.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-Floats">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Floats.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-Heap">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Heap.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-Loops">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Loops.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-ProductLines">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-ProductLines.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-Recursive">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Recursive.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
   <tasks name="ReachSafety-Sequentialized">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Sequentialized.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
   </tasks>
 
   <tasks name="SoftwareSystems-DeviceDriversLinux64-ReachSafety">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/SoftwareSystems-DeviceDriversLinux64-ReachSafety.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="-64"/>
@@ -82,34 +71,28 @@
   <option name="-witness">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
 
   <tasks name="MemSafety-Arrays">
-    <exclude>../sv-benchmarks/c/*/*_true-valid-memsafety*</exclude>
     <includesfile>../sv-benchmarks/c/MemSafety-Arrays.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
   </tasks>
   <tasks name="MemSafety-Heap">
-    <exclude>../sv-benchmarks/c/*/*_true-valid-memsafety*</exclude>
     <includesfile>../sv-benchmarks/c/MemSafety-Heap.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
   </tasks>
   <tasks name="MemSafety-LinkedLists">
-    <exclude>../sv-benchmarks/c/*/*_true-valid-memsafety*</exclude>
     <includesfile>../sv-benchmarks/c/MemSafety-LinkedLists.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
   </tasks>
   <tasks name="MemSafety-Other">
-    <exclude>../sv-benchmarks/c/*/*_true-valid-memsafety*</exclude>
     <includesfile>../sv-benchmarks/c/MemSafety-Other.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
   </tasks>
   <tasks name="MemSafety-TerminCrafted">
-    <exclude>../sv-benchmarks/c/*/*_true-valid-memsafety*</exclude>
     <includesfile>../sv-benchmarks/c/MemSafety-TerminCrafted.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
     <option name="-64"/>
   </tasks>
 
   <tasks name="SoftwareSystems-BusyBox-MemSafety">
-    <exclude>../sv-benchmarks/c/*/*_true-valid-memsafety*</exclude>
     <includesfile>../sv-benchmarks/c/SoftwareSystems-BusyBox-MemSafety.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
     <option name="-64"/>
@@ -121,19 +104,16 @@
   <option name="-witness">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
 
   <tasks name="NoOverflows-BitVectors">
-    <exclude>../sv-benchmarks/c/*/*_true-no-overflow*</exclude>
     <includesfile>../sv-benchmarks/c/NoOverflows-BitVectors.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
     <option name="-64"/>
   </tasks>
   <tasks name="NoOverflows-Other">
-    <exclude>../sv-benchmarks/c/*/*_true-no-overflow*</exclude>
     <includesfile>../sv-benchmarks/c/NoOverflows-Other.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
   </tasks>
 
   <tasks name="SoftwareSystems-BusyBox-NoOverflows">
-    <exclude>../sv-benchmarks/c/*/*_true-no-overflow*</exclude>
     <includesfile>../sv-benchmarks/c/SoftwareSystems-BusyBox-NoOverflows.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
     <option name="-64"/>

--- a/benchmark-defs/fshell-witness2test-validate-violation-witnesses.xml
+++ b/benchmark-defs/fshell-witness2test-validate-violation-witnesses.xml
@@ -11,68 +11,57 @@
   <option name="--graphml-witness">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
 
   <tasks name="ReachSafety-Arrays">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Arrays.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="-m32"/>
   </tasks>
   <tasks name="ReachSafety-BitVectors">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-BitVectors.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="-m32"/>
   </tasks>
   <tasks name="ReachSafety-ControlFlow">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-ControlFlow.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="-m32"/>
   </tasks>
   <tasks name="ReachSafety-ECA">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-ECA.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="-m32"/>
   </tasks>
   <tasks name="ReachSafety-Floats">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Floats.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="-m32"/>
   </tasks>
   <tasks name="ReachSafety-Heap">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Heap.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="-m32"/>
   </tasks>
   <tasks name="ReachSafety-Loops">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Loops.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="-m32"/>
   </tasks>
   <tasks name="ReachSafety-ProductLines">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-ProductLines.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="-m32"/>
   </tasks>
   <tasks name="ReachSafety-Recursive">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Recursive.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="-m32"/>
   </tasks>
   <tasks name="ReachSafety-Sequentialized">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Sequentialized.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="-m32"/>
   </tasks>
 
   <tasks name="SoftwareSystems-DeviceDriversLinux64-ReachSafety">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/SoftwareSystems-DeviceDriversLinux64-ReachSafety.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="-m64"/>
@@ -84,44 +73,37 @@
   <option name="--graphml-witness">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
 
   <tasks name="MemSafety-Arrays">
-    <exclude>../sv-benchmarks/c/*/*_true-valid-memsafety*</exclude>
     <includesfile>../sv-benchmarks/c/MemSafety-Arrays.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
     <option name="-m32"/>
   </tasks>
   <tasks name="MemSafety-Heap">
-    <exclude>../sv-benchmarks/c/*/*_true-valid-memsafety*</exclude>
     <includesfile>../sv-benchmarks/c/MemSafety-Heap.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
     <option name="-m32"/>
   </tasks>
   <tasks name="MemSafety-LinkedLists">
-    <exclude>../sv-benchmarks/c/*/*_true-valid-memsafety*</exclude>
     <includesfile>../sv-benchmarks/c/MemSafety-LinkedLists.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
     <option name="-m32"/>
   </tasks>
   <tasks name="MemSafety-Other">
-    <exclude>../sv-benchmarks/c/*/*_true-valid-memsafety*</exclude>
     <includesfile>../sv-benchmarks/c/MemSafety-Other.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
     <option name="-m32"/>
   </tasks>
   <tasks name="MemSafety-TerminCrafted">
-    <exclude>../sv-benchmarks/c/*/*_true-valid-memsafety*</exclude>
     <includesfile>../sv-benchmarks/c/MemSafety-TerminCrafted.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
     <option name="-m64"/>
   </tasks>
   <tasks name="MemSafety-MemCleanup">
-    <exclude>../sv-benchmarks/c/*/*_true-valid-memcleanup*</exclude>
     <includesfile>../sv-benchmarks/c/MemSafety-MemCleanup.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memcleanup.prp</propertyfile>
     <option name="-m32"/>
   </tasks>
 
   <tasks name="SoftwareSystems-BusyBox-MemSafety">
-    <exclude>../sv-benchmarks/c/*/*_true-valid-memsafety*</exclude>
     <includesfile>../sv-benchmarks/c/SoftwareSystems-BusyBox-MemSafety.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
     <option name="-m64"/>
@@ -133,20 +115,17 @@
   <option name="--graphml-witness">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
 
   <tasks name="NoOverflows-BitVectors">
-    <exclude>../sv-benchmarks/c/*/*_true-no-overflow*</exclude>
     <includesfile>../sv-benchmarks/c/NoOverflows-BitVectors.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
     <option name="-m64"/>
   </tasks>
   <tasks name="NoOverflows-Other">
-    <exclude>../sv-benchmarks/c/*/*_true-no-overflow*</exclude>
     <includesfile>../sv-benchmarks/c/NoOverflows-Other.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
     <option name="-m32"/>
   </tasks>
 
   <tasks name="SoftwareSystems-BusyBox-NoOverflows">
-    <exclude>../sv-benchmarks/c/*/*_true-no-overflow*</exclude>
     <includesfile>../sv-benchmarks/c/SoftwareSystems-BusyBox-NoOverflows.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
     <option name="-m64"/>

--- a/benchmark-defs/nitwit-validate-violation-witnesses.xml
+++ b/benchmark-defs/nitwit-validate-violation-witnesses.xml
@@ -13,52 +13,42 @@
         <!-- <option name="-rf">output/refined.witness.graphml</option> -->
 
         <tasks name="ReachSafety-Arrays">
-            <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
             <includesfile>../sv-benchmarks/c/ReachSafety-Arrays.set</includesfile>
             <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
         </tasks>
         <tasks name="ReachSafety-BitVectors">
-            <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
             <includesfile>../sv-benchmarks/c/ReachSafety-BitVectors.set</includesfile>
             <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
         </tasks>
         <tasks name="ReachSafety-ControlFlow">
-            <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
             <includesfile>../sv-benchmarks/c/ReachSafety-ControlFlow.set</includesfile>
             <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
         </tasks>
         <tasks name="ReachSafety-ECA">
-            <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
             <includesfile>../sv-benchmarks/c/ReachSafety-ECA.set</includesfile>
             <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
         </tasks>
         <tasks name="ReachSafety-Floats">
-            <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
             <includesfile>../sv-benchmarks/c/ReachSafety-Floats.set</includesfile>
             <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
         </tasks>
         <tasks name="ReachSafety-Heap">
-            <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
             <includesfile>../sv-benchmarks/c/ReachSafety-Heap.set</includesfile>
             <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
         </tasks>
         <tasks name="ReachSafety-Loops">
-            <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
             <includesfile>../sv-benchmarks/c/ReachSafety-Loops.set</includesfile>
             <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
         </tasks>
         <tasks name="ReachSafety-ProductLines">
-            <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
             <includesfile>../sv-benchmarks/c/ReachSafety-ProductLines.set</includesfile>
             <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
         </tasks>
         <tasks name="ReachSafety-Recursive">
-            <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
             <includesfile>../sv-benchmarks/c/ReachSafety-Recursive.set</includesfile>
             <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
         </tasks>
         <tasks name="ReachSafety-Sequentialized">
-            <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
             <includesfile>../sv-benchmarks/c/ReachSafety-Sequentialized.set</includesfile>
             <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
         </tasks>

--- a/benchmark-defs/uautomizer-validate-correctness-witnesses.xml
+++ b/benchmark-defs/uautomizer-validate-correctness-witnesses.xml
@@ -13,68 +13,57 @@
   <option name="--validate">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
 
   <tasks name="ReachSafety-Arrays">
-    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Arrays.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="--architecture">32bit</option>
   </tasks>
   <tasks name="ReachSafety-BitVectors">
-    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-BitVectors.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="--architecture">32bit</option>
   </tasks>
   <tasks name="ReachSafety-ControlFlow">
-    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-ControlFlow.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="--architecture">32bit</option>
   </tasks>
   <tasks name="ReachSafety-ECA">
-    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-ECA.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="--architecture">32bit</option>
   </tasks>
   <tasks name="ReachSafety-Floats">
-    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Floats.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="--architecture">32bit</option>
   </tasks>
   <tasks name="ReachSafety-Heap">
-    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Heap.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="--architecture">32bit</option>
   </tasks>
   <tasks name="ReachSafety-Loops">
-    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Loops.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="--architecture">32bit</option>
   </tasks>
   <tasks name="ReachSafety-ProductLines">
-    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-ProductLines.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="--architecture">32bit</option>
   </tasks>
   <tasks name="ReachSafety-Recursive">
-    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Recursive.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="--architecture">32bit</option>
   </tasks>
   <tasks name="ReachSafety-Sequentialized">
-    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Sequentialized.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="--architecture">32bit</option>
   </tasks>
 
   <tasks name="SoftwareSystems-DeviceDriversLinux64-ReachSafety">
-    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/SoftwareSystems-DeviceDriversLinux64-ReachSafety.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="--architecture">64bit</option>
@@ -86,56 +75,37 @@
   <option name="--validate">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
 
   <tasks name="MemSafety-Arrays">
-    <exclude>../sv-benchmarks/c/*/*_false-valid-deref*</exclude>
-    <exclude>../sv-benchmarks/c/*/*_false-valid-free*</exclude>
-    <exclude>../sv-benchmarks/c/*/*_false-valid-memtrack*</exclude>
     <includesfile>../sv-benchmarks/c/MemSafety-Arrays.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
     <option name="--architecture">32bit</option>
   </tasks>
   <tasks name="MemSafety-Heap">
-    <exclude>../sv-benchmarks/c/*/*_false-valid-deref*</exclude>
-    <exclude>../sv-benchmarks/c/*/*_false-valid-free*</exclude>
-    <exclude>../sv-benchmarks/c/*/*_false-valid-memtrack*</exclude>
     <includesfile>../sv-benchmarks/c/MemSafety-Heap.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
     <option name="--architecture">32bit</option>
   </tasks>
   <tasks name="MemSafety-LinkedLists">
-    <exclude>../sv-benchmarks/c/*/*_false-valid-deref*</exclude>
-    <exclude>../sv-benchmarks/c/*/*_false-valid-free*</exclude>
-    <exclude>../sv-benchmarks/c/*/*_false-valid-memtrack*</exclude>
     <includesfile>../sv-benchmarks/c/MemSafety-LinkedLists.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
     <option name="--architecture">32bit</option>
   </tasks>
   <tasks name="MemSafety-Other">
-    <exclude>../sv-benchmarks/c/*/*_false-valid-deref*</exclude>
-    <exclude>../sv-benchmarks/c/*/*_false-valid-free*</exclude>
-    <exclude>../sv-benchmarks/c/*/*_false-valid-memtrack*</exclude>
     <includesfile>../sv-benchmarks/c/MemSafety-Other.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
     <option name="--architecture">32bit</option>
   </tasks>
   <tasks name="MemSafety-TerminCrafted">
-    <exclude>../sv-benchmarks/c/*/*_false-valid-deref*</exclude>
-    <exclude>../sv-benchmarks/c/*/*_false-valid-free*</exclude>
-    <exclude>../sv-benchmarks/c/*/*_false-valid-memtrack*</exclude>
     <includesfile>../sv-benchmarks/c/MemSafety-TerminCrafted.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
     <option name="--architecture">64bit</option>
   </tasks>
   <tasks name="MemSafety-MemCleanup">
-    <exclude>../sv-benchmarks/c/*/*_false-valid-memcleanup*</exclude>
     <includesfile>../sv-benchmarks/c/MemSafety-MemCleanup.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memcleanup.prp</propertyfile>
     <option name="--architecture">32bit</option>
   </tasks>
 
   <tasks name="SoftwareSystems-BusyBox-MemSafety">
-    <exclude>../sv-benchmarks/c/*/*_false-valid-deref*</exclude>
-    <exclude>../sv-benchmarks/c/*/*_false-valid-free*</exclude>
-    <exclude>../sv-benchmarks/c/*/*_false-valid-memtrack*</exclude>
     <includesfile>../sv-benchmarks/c/SoftwareSystems-BusyBox-MemSafety.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
     <option name="--architecture">64bit</option>
@@ -147,20 +117,17 @@
   <option name="--validate">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
 
   <tasks name="NoOverflows-BitVectors">
-    <exclude>../sv-benchmarks/c/*/*_false-no-overflow*</exclude>
     <includesfile>../sv-benchmarks/c/NoOverflows-BitVectors.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
     <option name="--architecture">64bit</option>
   </tasks>
   <tasks name="NoOverflows-Other">
-    <exclude>../sv-benchmarks/c/*/*_false-no-overflow*</exclude>
     <includesfile>../sv-benchmarks/c/NoOverflows-Other.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
     <option name="--architecture">32bit</option>
   </tasks>
 
   <tasks name="SoftwareSystems-BusyBox-NoOverflows">
-    <exclude>../sv-benchmarks/c/*/*_false-no-overflow*</exclude>
     <includesfile>../sv-benchmarks/c/SoftwareSystems-BusyBox-NoOverflows.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
     <option name="--architecture">64bit</option>

--- a/benchmark-defs/uautomizer-validate-violation-witnesses.xml
+++ b/benchmark-defs/uautomizer-validate-violation-witnesses.xml
@@ -13,68 +13,57 @@
   <option name="--validate">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
 
   <tasks name="ReachSafety-Arrays">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Arrays.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="--architecture">32bit</option>
   </tasks>
   <tasks name="ReachSafety-BitVectors">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-BitVectors.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="--architecture">32bit</option>
   </tasks>
   <tasks name="ReachSafety-ControlFlow">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-ControlFlow.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="--architecture">32bit</option>
   </tasks>
   <tasks name="ReachSafety-ECA">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-ECA.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="--architecture">32bit</option>
   </tasks>
   <tasks name="ReachSafety-Floats">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Floats.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="--architecture">32bit</option>
   </tasks>
   <tasks name="ReachSafety-Heap">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Heap.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="--architecture">32bit</option>
   </tasks>
   <tasks name="ReachSafety-Loops">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Loops.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="--architecture">32bit</option>
   </tasks>
   <tasks name="ReachSafety-ProductLines">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-ProductLines.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="--architecture">32bit</option>
   </tasks>
   <tasks name="ReachSafety-Recursive">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Recursive.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="--architecture">32bit</option>
   </tasks>
   <tasks name="ReachSafety-Sequentialized">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/ReachSafety-Sequentialized.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="--architecture">32bit</option>
   </tasks>
 
   <tasks name="SoftwareSystems-DeviceDriversLinux64-ReachSafety">
-    <exclude>../sv-benchmarks/c/*/*_true-unreach-call*</exclude>
     <includesfile>../sv-benchmarks/c/SoftwareSystems-DeviceDriversLinux64-ReachSafety.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
     <option name="--architecture">64bit</option>
@@ -86,44 +75,37 @@
   <option name="--validate">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
 
   <tasks name="MemSafety-Arrays">
-    <exclude>../sv-benchmarks/c/*/*_true-valid-memsafety*</exclude>
     <includesfile>../sv-benchmarks/c/MemSafety-Arrays.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
     <option name="--architecture">32bit</option>
   </tasks>
   <tasks name="MemSafety-Heap">
-    <exclude>../sv-benchmarks/c/*/*_true-valid-memsafety*</exclude>
     <includesfile>../sv-benchmarks/c/MemSafety-Heap.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
     <option name="--architecture">32bit</option>
   </tasks>
   <tasks name="MemSafety-LinkedLists">
-    <exclude>../sv-benchmarks/c/*/*_true-valid-memsafety*</exclude>
     <includesfile>../sv-benchmarks/c/MemSafety-LinkedLists.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
     <option name="--architecture">32bit</option>
   </tasks>
   <tasks name="MemSafety-Other">
-    <exclude>../sv-benchmarks/c/*/*_true-valid-memsafety*</exclude>
     <includesfile>../sv-benchmarks/c/MemSafety-Other.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
     <option name="--architecture">32bit</option>
   </tasks>
   <tasks name="MemSafety-TerminCrafted">
-    <exclude>../sv-benchmarks/c/*/*_true-valid-memsafety*</exclude>
     <includesfile>../sv-benchmarks/c/MemSafety-TerminCrafted.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
     <option name="--architecture">64bit</option>
   </tasks>
   <tasks name="MemSafety-MemCleanup">
-    <exclude>../sv-benchmarks/c/*/*_true-valid-memcleanup*</exclude>
     <includesfile>../sv-benchmarks/c/MemSafety-MemCleanup.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memcleanup.prp</propertyfile>
     <option name="--architecture">32bit</option>
   </tasks>
 
   <tasks name="SoftwareSystems-BusyBox-MemSafety">
-    <exclude>../sv-benchmarks/c/*/*_true-valid-memsafety*</exclude>
     <includesfile>../sv-benchmarks/c/SoftwareSystems-BusyBox-MemSafety.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
     <option name="--architecture">64bit</option>
@@ -135,20 +117,17 @@
   <option name="--validate">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
 
   <tasks name="NoOverflows-BitVectors">
-    <exclude>../sv-benchmarks/c/*/*_true-no-overflow*</exclude>
     <includesfile>../sv-benchmarks/c/NoOverflows-BitVectors.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
     <option name="--architecture">64bit</option>
   </tasks>
   <tasks name="NoOverflows-Other">
-    <exclude>../sv-benchmarks/c/*/*_true-no-overflow*</exclude>
     <includesfile>../sv-benchmarks/c/NoOverflows-Other.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
     <option name="--architecture">32bit</option>
   </tasks>
 
   <tasks name="SoftwareSystems-BusyBox-NoOverflows">
-    <exclude>../sv-benchmarks/c/*/*_true-no-overflow*</exclude>
     <includesfile>../sv-benchmarks/c/SoftwareSystems-BusyBox-NoOverflows.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
     <option name="--architecture">64bit</option>
@@ -160,19 +139,16 @@
   <option name="--validate">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
 
   <tasks name="Termination-MainControlFlow">
-    <exclude>../sv-benchmarks/c/*/*_true-termination*</exclude>
     <includesfile>../sv-benchmarks/c/Termination-MainControlFlow.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/termination.prp</propertyfile>
     <option name="--architecture">64bit</option>
   </tasks>
   <tasks name="Termination-MainHeap">
-    <exclude>../sv-benchmarks/c/*/*_true-termination*</exclude>
     <includesfile>../sv-benchmarks/c/Termination-MainHeap.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/termination.prp</propertyfile>
     <option name="--architecture">64bit</option>
   </tasks>
   <tasks name="Termination-Other">
-    <exclude>../sv-benchmarks/c/*/*_true-termination*</exclude>
     <includesfile>../sv-benchmarks/c/Termination-Other.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/termination.prp</propertyfile>
     <option name="--architecture">32bit</option>


### PR DESCRIPTION
Since the change to the new yml format for specifying tasks,
these exclude directives have no effect anymore.