### PR TITLE
Add config for validating correctness witnesses with metaval/esbmc

### DIFF
--- a/benchmark-defs/metaval-esbmc-validate-correctness-witnesses.xml
+++ b/benchmark-defs/metaval-esbmc-validate-correctness-witnesses.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0"?>
+<!DOCTYPE benchmark PUBLIC "+//IDN sosy-lab.org//DTD BenchExec benchmark 1.9//EN" "https://www.sosy-lab.org/benchexec/benchmark-1.9.dtd">
+<benchmark tool="metaval" timelimit="15 min" hardtimelimit="16 min" memlimit="7 GB" cpuCores="2">
+
+<require cpuModel="Intel Xeon E3-1230 v5 @ 3.40 GHz" cpuCores="2"/>
+
+  <resultfiles>**.graphml</resultfiles>
+  <option name="--metaval">esbmc</option>
+  <option name="-s">kinduction</option>
+
+<rundefinition name="sv-comp20_prop-reachsafety">
+  <requiredfiles>../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</requiredfiles>
+  <option name="--witness">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
+
+  <tasks name="ReachSafety-Arrays">
+    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
+    <includesfile>../sv-benchmarks/c/ReachSafety-Arrays.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-BitVectors">
+    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
+    <includesfile>../sv-benchmarks/c/ReachSafety-BitVectors.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-ControlFlow">
+    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
+    <includesfile>../sv-benchmarks/c/ReachSafety-ControlFlow.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-ECA">
+    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
+    <includesfile>../sv-benchmarks/c/ReachSafety-ECA.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-Floats">
+    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
+    <includesfile>../sv-benchmarks/c/ReachSafety-Floats.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-Heap">
+    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
+    <includesfile>../sv-benchmarks/c/ReachSafety-Heap.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-Loops">
+    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
+    <includesfile>../sv-benchmarks/c/ReachSafety-Loops.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-ProductLines">
+    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
+    <includesfile>../sv-benchmarks/c/ReachSafety-ProductLines.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-Recursive">
+    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
+    <includesfile>../sv-benchmarks/c/ReachSafety-Recursive.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-Sequentialized">
+    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
+    <includesfile>../sv-benchmarks/c/ReachSafety-Sequentialized.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+
+  <tasks name="SoftwareSystems-DeviceDriversLinux64-ReachSafety">
+    <exclude>../sv-benchmarks/c/*/*_false-unreach-call*</exclude>
+    <includesfile>../sv-benchmarks/c/SoftwareSystems-DeviceDriversLinux64-ReachSafety.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+    <option name="-64"/>
+  </tasks>
+</rundefinition>
+
+</benchmark>


### PR DESCRIPTION
metaval will reduce the validation task to a reachability problem
and then solve this problem using ESBMC.