### PR TITLE
Disable validation of wrong witness type for CPA-Seq

### DIFF
--- a/benchmark-defs/cpa-seq-validate-correctness-witnesses.xml
+++ b/benchmark-defs/cpa-seq-validate-correctness-witnesses.xml
@@ -8,6 +8,7 @@
 
   <option name="-witnessValidation"/>
   <option name="-setprop">witness.checkProgramHash=false</option>
+  <option name="-setprop">witness.noViolationValidation=true</option>
   <option name="-heap">5000m</option>
   <option name="-benchmark"/>
   <option name="-setprop">cpa.predicate.memoryAllocationsAlwaysSucceed=true</option>

--- a/benchmark-defs/cpa-seq-validate-violation-witnesses.xml
+++ b/benchmark-defs/cpa-seq-validate-violation-witnesses.xml
@@ -8,6 +8,7 @@
 
   <option name="-witnessValidation"/>
   <option name="-setprop">witness.checkProgramHash=false</option>
+  <option name="-setprop">witness.noCorrectnessValidation=true</option>
   <option name="-heap">5000m</option>
   <option name="-benchmark"/>
   <option name="-setprop">cpa.predicate.memoryAllocationsAlwaysSucceed=true</option>


### PR DESCRIPTION
This will reduce the CPU time that is used for validation. Before, both
configurations essentially did the same analysis, just with other
limits. Now, we return UNKOWN as soon as we realize that we are given a
witness of the wrong type.

(This only became an issue after we switched to the new yml-format for specifying tasks. Before, we just excluded the wrong witness types by filtering according to the verdict in the filename.)