### PR TITLE
Fix meta-validation with ultimateautomizer

### DIFF
--- a/benchmark-defs/metaval-validate-violation-witnesses.xml
+++ b/benchmark-defs/metaval-validate-violation-witnesses.xml
@@ -123,6 +123,7 @@
   <requiredfiles>../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</requiredfiles>
   <option name="-metavalWitness">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
   <option name="-metaval">ultimateautomizer</option>
+  <option name="--metavalAdditionalPATH">/usr/lib/jvm/java-8-openjdk-amd64/bin</option>
 
   <tasks name="NoOverflows-BitVectors">
     <includesfile>../sv-benchmarks/c/NoOverflows-BitVectors.set</includesfile>
@@ -145,6 +146,7 @@
   <requiredfiles>../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</requiredfiles>
   <option name="-metavalWitness">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
   <option name="-metaval">ultimateautomizer</option>
+  <option name="--metavalAdditionalPATH">/usr/lib/jvm/java-8-openjdk-amd64/bin</option>
 
   <tasks name="Termination-MainControlFlow">
     <includesfile>../sv-benchmarks/c/Termination-MainControlFlow.set</includesfile>


### PR DESCRIPTION
Metaval uses SV-COMP19 versions of the wrapped verifiers.
UAutomizer from last year does not work with Java 11.
Java 8 is available on the competition's machines under the
path that is added in this commit.