### PR TITLE
Update metaval benchmark definition

### DIFF
--- a/benchmark-defs/metaval-validate-correctness-witnesses.xml
+++ b/benchmark-defs/metaval-validate-correctness-witnesses.xml
@@ -5,9 +5,8 @@
 <require cpuModel="Intel Xeon E3-1230 v5 @ 3.40 GHz" cpuCores="2"/>
 
   <resultfiles>**.graphml</resultfiles>
-  <option name="--metaval">esbmc</option>
-  <option name="--metavalWitnessType">correctness_witness</option>
-  <option name="-s">kinduction</option>
+  <option name="--metaval">cpachecker</option>
+  <option name="--metavalWitnessType">violation_witness</option>
 
 <rundefinition name="sv-comp20_prop-reachsafety">
   <requiredfiles>../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</requiredfiles>


### PR DESCRIPTION
We now use the best tool from SV-COMP'19 for validation of correctness witnesses in the reachability category