### PR TITLE
Changing the Java Ranger configuration for SV-COMP 2020

### DIFF
--- a/benchmark-defs/java-ranger.xml
+++ b/benchmark-defs/java-ranger.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE benchmark PUBLIC "+//IDN sosy-lab.org//DTD BenchExec benchmark 1.9//EN" "https://www.sosy-lab.org/benchexec/benchmark-1.9.dtd">
-<benchmark tool="java-ranger" timelimit="15 min" memlimit="15 GB" cpuCores="8">
+<benchmark tool="java-ranger" timelimit="15 min" memlimit="8 GB" cpuCores="2">
 
 <require cpuModel="Intel Xeon E3-1230 v5 @ 3.40 GHz" cpuCores="8"/>
 


### PR DESCRIPTION
This is the configuration I have been able to test JR with SV-COMP 2020 benchmarks on my own hardware. I would like to use the same configuration for JR in SV-COMP 2020. 