### PR TITLE
Rename configuration option to make it clearer

### DIFF
--- a/benchmark-defs/metaval-validate-correctness-witnesses.xml
+++ b/benchmark-defs/metaval-validate-correctness-witnesses.xml
@@ -9,7 +9,7 @@
 <rundefinition name="sv-comp20_prop-reachsafety">
   <requiredfiles>../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</requiredfiles>
   <option name="--metavalWitness">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
-  <option name="--metaval">cpachecker</option>
+  <option name="--metavalVerifierBackend">cpachecker</option>
 
   <tasks name="ReachSafety-Arrays">
     <includesfile>../sv-benchmarks/c/ReachSafety-Arrays.set</includesfile>

--- a/benchmark-defs/metaval-validate-violation-witnesses.xml
+++ b/benchmark-defs/metaval-validate-violation-witnesses.xml
@@ -9,7 +9,7 @@
 <rundefinition name="sv-comp20_prop-reachsafety">
   <requiredfiles>../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</requiredfiles>
   <option name="--metavalWitness">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
-  <option name="--metaval">cpachecker</option>
+  <option name="--metavalVerifierBackend">cpachecker</option>
 
 
   <tasks name="ReachSafety-Arrays">
@@ -73,7 +73,7 @@
 <rundefinition name="sv-comp20_prop-memsafety">
   <requiredfiles>../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</requiredfiles>
   <option name="--metavalWitness">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
-  <option name="--metaval">symbiotic</option>
+  <option name="--metavalVerifierBackend">symbiotic</option>
 
   <tasks name="MemSafety-Arrays">
     <includesfile>../sv-benchmarks/c/MemSafety-Arrays.set</includesfile>
@@ -121,7 +121,7 @@
 <rundefinition name="sv-comp20_prop-nooverflow">
   <requiredfiles>../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</requiredfiles>
   <option name="--metavalWitness">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
-  <option name="--metaval">ultimateautomizer</option>
+  <option name="--metavalVerifierBackend">ultimateautomizer</option>
   <option name="--metavalAdditionalPATH">/usr/lib/jvm/java-8-openjdk-amd64/bin</option>
 
   <tasks name="NoOverflows-BitVectors">
@@ -144,7 +144,7 @@
 <rundefinition name="sv-comp20_prop-termination">
   <requiredfiles>../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</requiredfiles>
   <option name="--metavalWitness">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
-  <option name="--metaval">ultimateautomizer</option>
+  <option name="--metavalVerifierBackend">ultimateautomizer</option>
   <option name="--metavalAdditionalPATH">/usr/lib/jvm/java-8-openjdk-amd64/bin</option>
 
   <tasks name="Termination-MainControlFlow">


### PR DESCRIPTION
The changes in this commit were done with:
sed -i 's|"--metaval"|"--metavalVerifierBackend"|g' \
benchmark-defs/metaval-*.xml

This depends on https://github.com/sosy-lab/benchexec/pull/530, so the benchmark definition for metaval after applying this PR will not work until https://github.com/sosy-lab/benchexec/pull/530 is merged.