### PR TITLE
Metaval:Add correctness validation for more categories

### DIFF
--- a/benchmark-defs/metaval-validate-correctness-witnesses.xml
+++ b/benchmark-defs/metaval-validate-correctness-witnesses.xml
@@ -68,4 +68,74 @@
   </tasks>
 </rundefinition>
 
+<rundefinition name="sv-comp20_prop-memsafety">
+  <requiredfiles>../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</requiredfiles>
+  <option name="--metavalWitness">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
+  <option name="--metavalVerifierBackend">symbiotic</option>
+
+  <tasks name="MemSafety-Arrays">
+    <includesfile>../sv-benchmarks/c/MemSafety-Arrays.set</includesfile>
+    <propertyfile expectedverdict="true">../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+    <option name="--32"/>
+  </tasks>
+  <tasks name="MemSafety-Heap">
+    <includesfile>../sv-benchmarks/c/MemSafety-Heap.set</includesfile>
+    <propertyfile expectedverdict="true">../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+    <option name="--32"/>
+  </tasks>
+  <tasks name="MemSafety-LinkedLists">
+    <includesfile>../sv-benchmarks/c/MemSafety-LinkedLists.set</includesfile>
+    <propertyfile expectedverdict="true">../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+    <option name="--32"/>
+  </tasks>
+  <tasks name="MemSafety-Other">
+    <includesfile>../sv-benchmarks/c/MemSafety-Other.set</includesfile>
+    <propertyfile expectedverdict="true">../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+    <option name="--32"/>
+  </tasks>
+  <tasks name="MemSafety-TerminCrafted">
+    <includesfile>../sv-benchmarks/c/MemSafety-TerminCrafted.set</includesfile>
+    <propertyfile expectedverdict="true">../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+  </tasks>
+  <tasks name="MemSafety-MemCleanup">
+    <includesfile>../sv-benchmarks/c/MemSafety-MemCleanup.set</includesfile>
+    <propertyfile expectedverdict="true">../sv-benchmarks/c/properties/valid-memcleanup.prp</propertyfile>
+    <option name="--32"/>
+  </tasks>
+
+  <tasks name="SoftwareSystems-BusyBox-MemSafety">
+    <includesfile>../sv-benchmarks/c/SoftwareSystems-BusyBox-MemSafety.set</includesfile>
+    <propertyfile expectedverdict="true">../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+  </tasks>
+  <tasks name="SoftwareSystems-OpenBSD-MemSafety">
+    <includesfile>../sv-benchmarks/c/SoftwareSystems-OpenBSD-MemSafety.set</includesfile>
+    <propertyfile expectedverdict="true">../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
+  </tasks>
+</rundefinition>
+
+<rundefinition name="sv-comp20_prop-nooverflow">
+  <requiredfiles>../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</requiredfiles>
+  <option name="--metavalWitness">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
+  <option name="--metavalVerifierBackend">ultimateautomizer</option>
+  <option name="--metavalAdditionalPATH">/usr/lib/jvm/java-8-openjdk-amd64/bin</option>
+  <option name="--full-output"/>
+
+  <tasks name="NoOverflows-BitVectors">
+    <includesfile>../sv-benchmarks/c/NoOverflows-BitVectors.set</includesfile>
+    <propertyfile expectedverdict="true">../sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
+    <option name="--architecture">64bit</option>
+  </tasks>
+  <tasks name="NoOverflows-Other">
+    <includesfile>../sv-benchmarks/c/NoOverflows-Other.set</includesfile>
+    <propertyfile expectedverdict="true">../sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
+    <option name="--architecture">32bit</option>
+  </tasks>
+
+  <tasks name="SoftwareSystems-BusyBox-NoOverflows">
+    <includesfile>../sv-benchmarks/c/SoftwareSystems-BusyBox-NoOverflows.set</includesfile>
+    <propertyfile expectedverdict="true">../sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
+    <option name="--architecture">64bit</option>
+  </tasks>
+</rundefinition>
+
 </benchmark>

--- a/benchmark-defs/metaval-validate-correctness-witnesses.xml
+++ b/benchmark-defs/metaval-validate-correctness-witnesses.xml
@@ -13,7 +13,7 @@
   <option name="-svcomp19"/>
   <option name="-heap">10000M</option>
   <option name="-benchmark"/>
-  <option name="-timelimit">900 s</option>
+  <option name="-timelimit">900s</option>
 
   <tasks name="ReachSafety-Arrays">
     <includesfile>../sv-benchmarks/c/ReachSafety-Arrays.set</includesfile>

--- a/benchmark-defs/metaval-validate-violation-witnesses.xml
+++ b/benchmark-defs/metaval-validate-violation-witnesses.xml
@@ -13,7 +13,7 @@
   <option name="-svcomp19"/>
   <option name="-heap">10000M</option>
   <option name="-benchmark"/>
-  <option name="-timelimit">900 s</option>
+  <option name="-timelimit">900s</option>
 
   <tasks name="ReachSafety-Arrays">
     <includesfile>../sv-benchmarks/c/ReachSafety-Arrays.set</includesfile>
@@ -77,7 +77,6 @@
   <requiredfiles>../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</requiredfiles>
   <option name="--metavalWitness">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
   <option name="--metavalVerifierBackend">symbiotic</option>
-  <option name="--sv-comp"/>
 
   <tasks name="MemSafety-Arrays">
     <includesfile>../sv-benchmarks/c/MemSafety-Arrays.set</includesfile>


### PR DESCRIPTION
There is actually no reason not to check correctness for nooverflows
and memsafety. uautomizer does this, so it is good to do this as well.
uautomizer was also best at verifying nooverflow last year, therefore
we choose it as verification backend for nooverflow correctness.
For memsafety we use symbiotic because of the same reason.