### PR TITLE
Update cpa-seq related benchmark definitions for svcomp21

### DIFF
--- a/benchmark-defs/cpa-seq-validate-correctness-witnesses.xml
+++ b/benchmark-defs/cpa-seq-validate-correctness-witnesses.xml
@@ -12,7 +12,7 @@
   <option name="-benchmark"/>
   <option name="-setprop">cpa.predicate.memoryAllocationsAlwaysSucceed=true</option>
 
-<rundefinition name="sv-comp20_prop-reachsafety">
+<rundefinition name="sv-comp21_prop-reachsafety">
   <requiredfiles>../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</requiredfiles>
   <option name="-witness">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
 

--- a/benchmark-defs/cpa-seq-validate-violation-witnesses.xml
+++ b/benchmark-defs/cpa-seq-validate-violation-witnesses.xml
@@ -17,7 +17,7 @@
   <option name="-setprop">cpa.smg.zeroingMemoryAllocation=calloc,kzalloc,kcalloc,kzalloc_node,ldv_zalloc</option>
   <option name="-setprop">cpa.smg.deallocationFunctions=free,kfree,kfree_const</option>
 
-<rundefinition name="sv-comp20_prop-reachsafety">
+<rundefinition name="sv-comp21_prop-reachsafety">
   <requiredfiles>../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</requiredfiles>
   <option name="-witness">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
 
@@ -79,7 +79,7 @@
   </tasks>
 </rundefinition>
 
-<rundefinition name="sv-comp20_prop-memsafety">
+<rundefinition name="sv-comp21_prop-memsafety">
   <requiredfiles>../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</requiredfiles>
   <option name="-witness">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
 
@@ -121,7 +121,7 @@
   </tasks>
 </rundefinition>
 
-<rundefinition name="sv-comp20_prop-nooverflow">
+<rundefinition name="sv-comp21_prop-nooverflow">
   <requiredfiles>../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</requiredfiles>
   <option name="-witness">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
 
@@ -142,7 +142,7 @@
   </tasks>
 </rundefinition>
 
-<rundefinition name="sv-comp20_prop-termination">
+<rundefinition name="sv-comp21_prop-termination">
   <requiredfiles>../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</requiredfiles>
   <option name="-witness">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
 

--- a/benchmark-defs/cpa-seq.xml
+++ b/benchmark-defs/cpa-seq.xml
@@ -6,12 +6,12 @@
 
   <resultfiles>**.graphml</resultfiles>
 
-  <option name="-svcomp20"/>
+  <option name="-svcomp21"/>
   <option name="-heap">10000M</option>
   <option name="-benchmark"/>
   <option name="-timelimit">900 s</option>
 
-<rundefinition name="sv-comp20_prop-reachsafety">
+<rundefinition name="sv-comp21_prop-reachsafety">
   <tasks name="ReachSafety-Arrays">
     <includesfile>../sv-benchmarks/c/ReachSafety-Arrays.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
@@ -70,7 +70,7 @@
   </tasks>
 </rundefinition>
 
-<rundefinition name="sv-comp20_prop-memsafety">
+<rundefinition name="sv-comp21_prop-memsafety">
   <tasks name="MemSafety-Arrays">
     <includesfile>../sv-benchmarks/c/MemSafety-Arrays.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/valid-memsafety.prp</propertyfile>
@@ -109,7 +109,7 @@
   </tasks>
 </rundefinition>
 
-<rundefinition name="sv-comp20_prop-nooverflow">
+<rundefinition name="sv-comp21_prop-nooverflow">
   <tasks name="NoOverflows-BitVectors">
     <includesfile>../sv-benchmarks/c/NoOverflows-BitVectors.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/no-overflow.prp</propertyfile>
@@ -127,7 +127,7 @@
   </tasks>
 </rundefinition>
 
-<rundefinition name="sv-comp20_prop-termination">
+<rundefinition name="sv-comp21_prop-termination">
   <tasks name="Termination-MainControlFlow">
     <includesfile>../sv-benchmarks/c/Termination-MainControlFlow.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/termination.prp</propertyfile>

--- a/benchmark-defs/cpa-witness2test-validate-violation-witnesses.xml
+++ b/benchmark-defs/cpa-witness2test-validate-violation-witnesses.xml
@@ -14,7 +14,7 @@
   <option name="-setprop">cpa.callstack.skipVoidRecursion=true</option>
   <option name="-setprop">cpa.callstack.skipFunctionPointerRecursion=true</option>
 
-<rundefinition name="sv-comp20_prop-reachsafety">
+<rundefinition name="sv-comp21_prop-reachsafety">
   <requiredfiles>../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</requiredfiles>
   <option name="-witness">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
 
@@ -71,7 +71,7 @@
   </tasks>
 </rundefinition>
 
-<rundefinition name="sv-comp20_prop-memsafety">
+<rundefinition name="sv-comp21_prop-memsafety">
   <requiredfiles>../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</requiredfiles>
   <option name="-witness">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
 
@@ -109,7 +109,7 @@
   </tasks>
 </rundefinition>
 
-<rundefinition name="sv-comp20_prop-nooverflow">
+<rundefinition name="sv-comp21_prop-nooverflow">
   <requiredfiles>../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</requiredfiles>
   <option name="-witness">../../results-verified/LOGDIR/${rundefinition_name}.${taskdef_name}/witness.graphml</option>
 


### PR DESCRIPTION
Changes include:
- the renaming of rundefinition names from `*sv-comp20*` to `*sv-comp21*`
- updating the config option to `-svcomp21` (was `-svcomp20` previously)