### PR TITLE
Adding gazer-theta benchmark definition

### DIFF
--- a/benchmark-defs/gazer-theta.xml
+++ b/benchmark-defs/gazer-theta.xml
@@ -9,7 +9,7 @@
   <!-- No options, the starter script handles everything. The only possible option would be the output flag, without that the witnesses and test harnesses are generated into the working directory -->
 
   <!-- ReachSafety only and opting out from sub-categories Sequentialized, Heaps, Arrays -->
-<rundefinition name="sv-comp20_prop-reachsafety">
+<rundefinition name="sv-comp21_prop-reachsafety">
   <tasks name="ReachSafety-BitVectors">
     <includesfile>../sv-benchmarks/c/ReachSafety-BitVectors.set</includesfile>
     <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>

--- a/benchmark-defs/gazer-theta.xml
+++ b/benchmark-defs/gazer-theta.xml
@@ -8,6 +8,7 @@
 
   <!-- No options, the starter script handles everything. The only possible option would be the output flag, without that the witnesses and test harnesses are generated into the working directory -->
 
+  <!-- ReachSafety only and opting out from sub-categories Sequentialized, Heaps, Arrays -->
 <rundefinition name="sv-comp20_prop-reachsafety">
   <tasks name="ReachSafety-BitVectors">
     <includesfile>../sv-benchmarks/c/ReachSafety-BitVectors.set</includesfile>

--- a/benchmark-defs/gazer-theta.xml
+++ b/benchmark-defs/gazer-theta.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<!DOCTYPE benchmark PUBLIC "+//IDN sosy-lab.org//DTD BenchExec benchmark 1.9//EN" "https://www.sosy-lab.org/benchexec/benchmark-1.9.dtd">
+<benchmark tool="gazer-theta" timelimit="15 min" hardtimelimit="16 min" memlimit="15 GB" cpuCores="8">
+
+<require cpuModel="Intel Xeon E3-1230 v5 @ 3.40 GHz" cpuCores="8"/>
+
+  <resultfiles>**.graphml</resultfiles>
+
+  <!-- No options, the starter script handles everything. The only possible option would be the output flag, without that the witnesses and test harnesses are generated into the working directory -->
+
+<rundefinition name="sv-comp20_prop-reachsafety">
+  <tasks name="ReachSafety-BitVectors">
+    <includesfile>../sv-benchmarks/c/ReachSafety-BitVectors.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-ControlFlow">
+    <includesfile>../sv-benchmarks/c/ReachSafety-ControlFlow.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-ECA">
+    <includesfile>../sv-benchmarks/c/ReachSafety-ECA.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-Floats">
+    <includesfile>../sv-benchmarks/c/ReachSafety-Floats.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-Loops">
+    <includesfile>../sv-benchmarks/c/ReachSafety-Loops.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-ProductLines">
+    <includesfile>../sv-benchmarks/c/ReachSafety-ProductLines.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+  <tasks name="ReachSafety-Recursive">
+    <includesfile>../sv-benchmarks/c/ReachSafety-Recursive.set</includesfile>
+    <propertyfile>../sv-benchmarks/c/properties/unreach-call.prp</propertyfile>
+  </tasks>
+</rundefinition>
+
+</benchmark>


### PR DESCRIPTION
We would like to participate with gazer-theta in the following sub-categories of ReachSafety: *Bitvectors, ControlFlow, ECA, Floats, Loops, Productlines, Recursive*.

Do I understand right, that we have to opt-out on the SVComp form from every category except the above listed ones and from the *1. ReachSafety* category, as to take part in that, we would have to participate in *Heaps*, *Arrays* and *Sequentialized* as well?

Thanks in advance!