### PR TITLE
Update runexec parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ that has mostly the same packages installed as the competition machines:
 --container
 --read-only-dir /
 --hidden-dir /home
---overlay-dir /etc
 --hidden-dir /var/lib/cloudy # environment-specific
 --set-cgroup-value pids.max=5000
 --output-directory <work-dir>


### PR DESCRIPTION
I removed one parameter to reduce the potential impact of https://github.com/sosy-lab/benchexec/issues/621. This does not actually change anything relevant of how the container is configured because since BenchExec 1.18 all features that previously required overlay mode for `/etc` now also work with other modes (read-only mode in this case).